### PR TITLE
Fix bug with default_value parameter in configspace conversion function

### DIFF
--- a/labwatch/converters/convert_to_configspace.py
+++ b/labwatch/converters/convert_to_configspace.py
@@ -47,18 +47,18 @@ def convert_simple_param(name, param):
                 basic_choices.append(choice)        
         return csh.CategoricalHyperparameter(name=name,
                                              choices=basic_choices,
-                                             default=basic_choices[0])
+                                             default_value=basic_choices[0])
     elif param["_class"] == 'UniformFloat':
         return csh.UniformFloatHyperparameter(name=name,
                                               lower=param["lower"],
                                               upper=param["upper"],
-                                              default=param["default"],
+                                              default_value=param["default"],
                                               log=param["log_scale"])
     elif param["_class"] == 'UniformInt':
         return csh.UniformIntegerHyperparameter(name=name,
                                                 lower=param["lower"],
                                                 upper=param["upper"],
-                                                default=param["default"],
+                                                default_value=param["default"],
                                                 log=param["log_scale"])
     elif param["_class"] == 'UniformNumber':
         ptype = str_to_types[param["type"]]
@@ -66,13 +66,13 @@ def convert_simple_param(name, param):
             return csh.UniformFloatHyperparameter(name=name,
                                                   lower=param["lower"],
                                                   upper=param["upper"],
-                                                  default=param["default"],
+                                                  default_value=param["default"],
                                                   log=param["log_scale"])
         elif ptype == int:
             return csh.UniformIntegerHyperparameter(name=name,
                                                     lower=param["lower"],
                                                     upper=param["upper"],
-                                                    default=param["default"],
+                                                    default_value=param["default"],
                                                     log=param["log_scale"])
         else:
             raise ValueError("Don't know how to represent UniformNumber with "


### PR DESCRIPTION
As described in #10, the hyperparameter classes in the ConfigSpace package expect a [_default_value_](https://github.com/automl/ConfigSpace/blob/master/ConfigSpace/hyperparameters.pyx) argument, while the [convert_simple_param](https://github.com/automl/labwatch/blob/master/labwatch/converters/convert_to_configspace.py) function currently gives them a parameter called _default_.
The name of the argument has probably been changed in one of the packages, rendering them incompatible. This PR fixes #10.